### PR TITLE
Add option to support dry-run instead of try/commit.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ bearwall2_options:
 
 bearwall2_enable_backports: false
 bearwall2_backport_kernel_nftables: false
+bearwall2_dry_run: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,15 @@
 ---
 
+- name: dry-run bearwall2
+  command: "bearwall2 dry-run"
+  when: bearwall2_dry_run
+  listen: "apply bearwall2"
+
 - name: try bearwall2
   command: "bearwall2 try"
   notify: "test connectivity bearwall2"
+  when: not bearwall2_dry_run
+  listen: "apply bearwall2"
 
 - name: test connectivity bearwall2
   wait_for_connection:

--- a/tasks/configure-class.yml
+++ b/tasks/configure-class.yml
@@ -4,4 +4,4 @@
   template:
     src: if
     dest: "/etc/bearwall2/classes.d/{{ item.name }}"
-  notify: try bearwall2
+  notify: apply bearwall2

--- a/tasks/configure-interface.yml
+++ b/tasks/configure-interface.yml
@@ -6,11 +6,11 @@
     dest: "/etc/bearwall2/interfaces.d/{{ item.name }}.if"
     state: link
   when: "'class' in item"
-  notify: try bearwall2
+  notify: apply bearwall2
 
 - name: Configure bearwall interface {{ item.name }}
   template:
     src: if
     dest: "/etc/bearwall2/interfaces.d/{{ item.name }}.if"
   when: "'class' not in item"
-  notify: try bearwall2
+  notify: apply bearwall2

--- a/tasks/configure-ruleset.yml
+++ b/tasks/configure-ruleset.yml
@@ -4,4 +4,4 @@
   template:
     src: ruleset
     dest: "/etc/bearwall2/rulesets.d/{{ item.name }}.rule"
-  notify: try bearwall2
+  notify: apply bearwall2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,7 +87,7 @@
   template:
     src: "bearwall2.conf"
     dest: "/etc/bearwall2/bearwall2.conf"
-  notify: try bearwall2
+  notify: apply bearwall2
 
 - name: Configure bearwall2 rulesets
   include_tasks: configure-ruleset.yml


### PR DESCRIPTION
I'd prefer not to reload the firewall and reset the SSH connection during a particular playbook I use, so want the option to use ```bearwall2 dry-run``` instead of ```bearwall2 try```, reconnect, ```bearwall2 commit``` when the configuration changes.

Using ```dry-run``` should still give many of the benefits of checking the rules/configuration for correctness.

The default behaviour is unchanged, the new dry-run behaviour needs to be explicitly enabled by setting ```bearwall2_dry_run: true```.