### PR TITLE
Change default missing option to lazy to match bearwall2 default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ bearwall2_interfaces: []
 bearwall2_options:
   logging: "nflog"
   conntrack: "stateful"
-  missing: "withhold"
+  missing: "lazy"
   rollback_delay: "30"
   always_ifname: "ppp"
 


### PR DESCRIPTION
Use same default missing option as bearwall2, changed here: https://github.com/bearwall-firewall/bearwall2/pull/25