### PR TITLE
Improve GPG security for bearwall2 apt repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+bearwall2_apt_key_fingerprint: "C704B6DE77346EBAE0D229DA26EA35E7A5ED1FFE"
+
 bearwall2_rulesets: []
 bearwall2_classes: []
 bearwall2_interfaces: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,15 +47,30 @@
     id: "6ABA09963E518866C29FA6C10F0921E4A2D0D6AE"
     state: absent
 
+- name: Remove bearwall2 repository entry without signed-by
+  apt_repository:
+    repo: "deb https://dl.cloudsmith.io/public/bearwall/bearwall2/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+    state: absent
+
+- name: Remove bearwall2 cloudsmith GPG signing key from default keyring
+  apt_key:
+    id: "{{ bearwall2_apt_key_fingerprint }}"
+    keyring: "/etc/apt/trusted.gpg"
+    state: absent
+
 - name: Import bearwall2 cloudsmith GPG signing key
   apt_key:
-    id: "C704B6DE77346EBAE0D229DA26EA35E7A5ED1FFE"
+    id: "{{ bearwall2_apt_key_fingerprint }}"
     url: "https://dl.cloudsmith.io/public/bearwall/bearwall2/gpg.26EA35E7A5ED1FFE.key"
+    keyring: "/usr/share/keyrings/bearwall2.gpg"
     state: present
 
 - name: Add bearwall2 cloudsmith repository
   apt_repository:
-    repo: "deb https://dl.cloudsmith.io/public/bearwall/bearwall2/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+    repo: >-
+      deb [signed-by=/usr/share/keyrings/bearwall2.gpg]
+      https://dl.cloudsmith.io/public/bearwall/bearwall2/deb/{{ ansible_distribution | lower }}
+      {{ ansible_distribution_release }} main
     state: present
 
 - name: Install packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
       deb [signed-by=/usr/share/keyrings/bearwall2.gpg]
       https://dl.cloudsmith.io/public/bearwall/bearwall2/deb/{{ ansible_distribution | lower }}
       {{ ansible_distribution_release }} main
+    filename: bearwall2
     state: present
 
 - name: Install packages


### PR DESCRIPTION
* Don't store the GPG key for bearwall2 in /etc/apt/trusted.gpg. Instead store it under /etc/apt/trusted.gpg.
* Also remove the GPG key from /etc/apt/trusted.gpg.
* Use `signed-by` in the bearwall2 apt repository entry to use the GPG key under the new location for signature checks.