### PR TITLE
Gather package facts after nftables is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: Gather package versions
-  package_facts:
-    manager: auto
-
 - name: Get dpkg host architecture
   command: dpkg --print-architecture
   changed_when: false
@@ -64,6 +60,10 @@
       - bearwall2
       - ulogd2
     state: present
+
+- name: Gather package versions
+  package_facts:
+    manager: auto
 
 - name: Check kernel version
   fail:


### PR DESCRIPTION
Fixes error:

```
TASK [bearwall2 : Check nftables version] *****************************************************************************************************************************************************************
fatal: [debian-bullseye]: FAILED! => {"msg": "The conditional check 'ansible_facts.packages['nftables'][0]['version'] is version('0.9.1', '<')' failed. The error was: error while evaluating conditional (ansible_facts.packages['nftables'][0]['version'] is version('0.9.1', '<')): 'dict object' has no attribute 'nftables'\n\nThe error appears to be in '~/.ansible/roles/bearwall2/tasks/main.yml': line 89, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Check nftables version\n  ^ here\n"}
...ignoring
```

This is occurring because `ansible_facts.packages['nftables']` won't be present until nftables is installed and the package facts could be retrieved before nftables is installed.